### PR TITLE
migrate Interrupts from diplomatic to rocket

### DIFF
--- a/diplomatic/src/rocket/CSR.scala
+++ b/diplomatic/src/rocket/CSR.scala
@@ -241,7 +241,7 @@ class CSRDecodeIO(implicit p: Parameters) extends CoreBundle {
 class CSRFileIO(implicit p: Parameters) extends CoreBundle
     with HasCoreParameters {
   val ungated_clock = Input(Clock())
-  val interrupts = Input(new CoreInterrupts())
+  val interrupts = Input(new CoreInterrupts(usingSupervisor, usingNMI, coreParams.nLocalInterrupts, resetVectorLen, tileParams.beuAddr))
   val hartid = Input(UInt(hartIdLen.W))
   val rw = new Bundle {
     val addr = Input(UInt(CSR.ADDRSZ.W))

--- a/diplomatic/src/tile/Core.scala
+++ b/diplomatic/src/tile/Core.scala
@@ -133,16 +133,12 @@ abstract class CoreModule(implicit val p: Parameters) extends Module
 abstract class CoreBundle(implicit val p: Parameters) extends ParameterizedBundle()(p)
   with HasCoreParameters
 
-class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
-  val buserror = tileParams.beuAddr.map(a => Bool())
-}
-
 trait HasCoreIO extends HasTileParameters {
   implicit val p: Parameters
   val io = new CoreBundle()(p) {
     val hartid = UInt(hartIdLen.W).asInput
     val reset_vector = UInt(resetVectorLen.W).asInput
-    val interrupts = new CoreInterrupts().asInput
+    val interrupts = new CoreInterrupts(usingSupervisor, usingNMI, coreParams.nLocalInterrupts, resetVectorLen, tileParams.beuAddr).asInput
     val imem  = new FrontendIO
     val dmem = new HellaCacheIO
     val ptw = new DatapathPTWIO().flip

--- a/diplomatic/src/tile/Interrupts.scala
+++ b/diplomatic/src/tile/Interrupts.scala
@@ -3,27 +3,11 @@
 package org.chipsalliance.rockettile
 
 import Chisel._
-
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
-
-class NMI(val w: Int) extends Bundle {
-  val rnmi = Bool()
-  val rnmi_interrupt_vector = UInt(w.W)
-  val rnmi_exception_vector = UInt(w.W)
-}
-
-class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {
-  val debug = Bool()
-  val mtip = Bool()
-  val msip = Bool()
-  val meip = Bool()
-  val seip = usingSupervisor.option(Bool())
-  val lip = Vec(coreParams.nLocalInterrupts, Bool())
-  val nmi = usingNMI.option(new NMI(resetVectorLen))
-}
+import org.chipsalliance.rocket.CoreInterrupts
 
 // Use diplomatic interrupts to external interrupts from the subsystem into the tile
 trait SinksExternalInterrupts { this: BaseTile =>
@@ -67,7 +51,7 @@ trait SinksExternalInterrupts { this: BaseTile =>
   }
 
   // go from flat diplomatic Interrupts to bundled TileInterrupts
-  def decodeCoreInterrupts(core: TileInterrupts): Unit = {
+  def decodeCoreInterrupts(core: CoreInterrupts): Unit = {
     val async_ips = Seq(core.debug)
     val periph_ips = Seq(
       core.msip,

--- a/rocket/src/Interrupts.scala
+++ b/rocket/src/Interrupts.scala
@@ -1,0 +1,19 @@
+package org.chipsalliance.rocket
+
+import chisel3._
+class NMI(val w: Int) extends Bundle {
+  val rnmi = Bool()
+  val rnmi_interrupt_vector = UInt(w.W)
+  val rnmi_exception_vector = UInt(w.W)
+}
+
+class CoreInterrupts(usingSupervisor: Boolean, usingNMI: Boolean, nLocalInterrupts: Int, resetVectorLen: Int, beuAddr: Option[BigInt]) extends Bundle {
+  val debug = Bool()
+  val mtip = Bool()
+  val msip = Bool()
+  val meip = Bool()
+  val seip = if (usingSupervisor) Some(Bool()) else None
+  val lip = Vec(nLocalInterrupts, Bool())
+  val nmi = if (usingNMI) Some(new NMI(resetVectorLen)) else None
+  val buserror = beuAddr.map(_ => Bool())
+}


### PR DESCRIPTION
1. remove CDE usage in these to Bundles.
2. remove TileInterrupts Bundle.
